### PR TITLE
feat: add quiet flag

### DIFF
--- a/pkg/argparse/args.go
+++ b/pkg/argparse/args.go
@@ -107,6 +107,8 @@ func (a *Argument) buildFlags() *flag.FlagSet {
 
 	f.BoolVar(&a.version, "version", false, "Show the version of kitexcall.")
 
+	f.BoolVar(&a.Quiet, "quiet", false, "Enable only print rpc response.")
+
 	return f
 }
 
@@ -279,6 +281,7 @@ func (a *Argument) BuildConfig() *config.Config {
 		MetaPersistent: a.MetaPersistent,
 		MetaBackward:   a.MetaBackward,
 		BizError:       a.BizError,
+		Quiet:          a.Quiet,
 	}
 }
 

--- a/pkg/client/generic_client.go
+++ b/pkg/client/generic_client.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/bytedance/gopkg/cloud/metainfo"
@@ -83,8 +84,10 @@ func (c *GenericClientBase) Output() error {
 		return err
 	}
 
-	log.Success()
-	log.Println(result)
+	if !c.Conf.Quiet {
+		log.Success()
+	}
+	fmt.Print(result)
 
 	if c.Conf.MetaBackward {
 		log.Println("\033[32mReceived metainfo from server: \033[0m")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	MetaPersistent map[string]string
 	MetaBackward   bool
 	BizError       bool
+	Quiet          bool
 }
 
 type ConfigBuilder interface {


### PR DESCRIPTION
#### What type of PR is this?

I have a requirement to save the return result of the rpc，This feature is similar to curl's -o parameter.

#### (Optional) Translate the PR title into Chinese.

infra tearm 有一个需求，需要通过 shell kitexcall 来访问  rpcserver，通过解析返回的 json 来做进一步的操作。而当前的 kitexcall 返回值里有 status 和 rpc response 信息，有时还会有 kitex sdk 的输出，这样的返回数据没法做 decode 解析。😁 

```bash
$ ./kitexcall  -t protobuf -idl-path ~/west/starryshore/modules/ticket_server/idl/ticket.proto -e 10.10.100.2:30015 -m TicketModel/ListTicketInfo -d '{"page": 1, "page_size": 1}'  -o kk.log

[Status]: Success

$ cat kk.log | jq .total
29
```
